### PR TITLE
Fix list of nopaste services

### DIFF
--- a/interop/nopaste.md
+++ b/interop/nopaste.md
@@ -15,16 +15,16 @@ on lines of code and similar.
 
 Nopaste services for different code purposes and languages:
 
-* [Codejaw](http://codejaw.com/) - Multiple languages
 * [codepad](http://codepad.org/) - Multiple languages
 * [CodePen](http://codepen.io/) - HTML, CSS and JavaScript
+* [ControlC](https://controlc.com/) - Multiple languages
 * [Extends Class](https://extendsclass.com/sqlite-browser.html) - SQL (SQLite)
 * [GitHub Gist](https://gist.github.com/) - Multiple languages
 * [hastebin](http://hastebin.com/) - Simple, Notepad-style editor
 * [JSFiddle](https://jsfiddle.net/) - JavaScript
+* [NoPaste.ml](https://nopaste.ml) - Multiple languages, privacy-based
 * [Pastebin](http://pastebin.com/) - Multiple languages
-* [Pastee.ee](https://paste.ee/) - Multiple languages
-* [Pasted.co](http://pasted.co/) - Multiple languages
+* [Paste.ee](https://paste.ee/) - Multiple languages
 * [PasteFS](https://www.pastefs.com/) - Simple text editor
 * [PHPTester](http://phptester.net) - PHP
 * [Regex 101](https://regex101.com/) - Regular expressions


### PR DESCRIPTION
- `Pasted.co` now redirects to `ControlC.com`
- Fixed `Pastee.ee` -> `Paste.ee`
- Added `NoPaste.ml`