### PR TITLE
Fix tests.

### DIFF
--- a/.github/test.php
+++ b/.github/test.php
@@ -41,9 +41,15 @@ foreach ($iterator as $pathName => $fileInfo) {
     // Internal links
     preg_match_all('/\[.+\]\(((?!http)\/.+)(\).*)/i', $content, $matches);
     foreach ($matches[1] as $file) {
-        if (!file_exists($docsDir.$file)) {
-            $exitCode = 2;
-            echo '[WARNING] Missing link in '.$pathName.': '.$file.PHP_EOL;
+        $item = preg_replace('~[\\\/]~', DIRECTORY_SEPARATOR, $docsDir.$file);
+        if (!file_exists($item)) {
+            if (substr($item, -1) === DIRECTORY_SEPARATOR) {
+                $then = substr($item, 0, -1) . '.md';
+                if (!file_exists($then)) {
+                    $exitCode = 2;
+                    echo '[WARNING] Missing link in '.$pathName.': '.$file.PHP_EOL;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Tests seem to be have been failing due to the non-existence of the internal paths cited by certain links in our markdown files. However, the non-existence of those paths is to be expected, seeing as those paths are "friendly" paths, rather than pointing to the literal address of the files associated by those paths (i.e., when requested, the paths will work correctly, because they're routed to the intended files, which normally are `.md` files).

This commit does two things.
- Normalises whichever directory separator appears literally in our markdown files to that which is expected by the system wherever the tests are performed (a theoretical problem at my own dev machine, but I should note, not related at all to the cause of the test failures actually seen here).
- When the literal path points to a non-existent file, try then checking for the existence of a markdown file equivalent of the literal path instead (at my end, at least, it seems to resolve the test failures).

Review requested in case I've misunderstood something here, or in case I've missed anything. Cheers. :+1:
